### PR TITLE
QUIZLET-5: Implement Sign Out Functionality

### DIFF
--- a/lib/bloc/authentication_bloc/authentication_bloc.dart
+++ b/lib/bloc/authentication_bloc/authentication_bloc.dart
@@ -9,7 +9,7 @@ class AuthenticationBloc extends ChangeNotifier {
   final AuthenticationService _authenticationService;
 
   /// The current state of authentication.
-  AuthenticationState _state = AuthenticationInitial();
+  AuthenticationState _state = AuthenticationUnauthenticated();
 
   /// Getter for the current authentication state.
   AuthenticationState get state => _state;
@@ -21,7 +21,11 @@ class AuthenticationBloc extends ChangeNotifier {
 
     try {
       final user = await _authenticationService.getCurrentUser();
-      _state = AuthenticationAuthenticated(user);
+      if (user == null) {
+        _state = AuthenticationUnauthenticated();
+      } else {
+        _state = AuthenticationAuthenticated(user);
+      }
     } on AuthenticationException catch (e) {
       _state = AuthenticationError(e);
     } finally {
@@ -69,7 +73,16 @@ class AuthenticationBloc extends ChangeNotifier {
 
   /// Signs out the current user.
   Future<void> signOut() async {
-    // TODO: Implement sign out
-    throw UnimplementedError();
+    _state = AuthenticationLoading();
+    notifyListeners();
+
+    try {
+      await _authenticationService.signOut();
+      _state = AuthenticationUnauthenticated();
+    } on AuthenticationException catch (e) {
+      _state = AuthenticationError(e);
+    } finally {
+      notifyListeners();
+    }
   }
 }

--- a/lib/bloc/authentication_bloc/authentication_bloc_state.dart
+++ b/lib/bloc/authentication_bloc/authentication_bloc_state.dart
@@ -10,7 +10,7 @@ sealed class AuthenticationState {
 }
 
 /// Represents the initial state of authentication.
-class AuthenticationInitial extends AuthenticationState {}
+class AuthenticationUnauthenticated extends AuthenticationState {}
 
 /// Represents the loading state of authentication.
 class AuthenticationLoading extends AuthenticationState {}
@@ -38,8 +38,6 @@ class AuthenticationError extends AuthenticationState {
 
   String get errorMessage {
     switch (error) {
-      case UnauthorizedException():
-        return AppTexts.unauthorizedAccess;
       case UserNotFoundException():
         return AppTexts.userNotFound;
       case WrongEmailOrPasswordException():

--- a/lib/data/authentication_service.dart
+++ b/lib/data/authentication_service.dart
@@ -8,10 +8,10 @@ class AuthenticationService {
   /// Retrieves the currently authenticated user.
   ///
   /// Returns an [AppUser] if a user is authenticated, otherwise returns null.
-  Future<AppUser> getCurrentUser() async {
+  Future<AppUser?> getCurrentUser() async {
     final firebaseUser = _firebaseAuth.currentUser;
     if (firebaseUser == null) {
-      throw UnauthorizedException();
+      return null;
     }
 
     return AppUser.fromFirebaseUser(firebaseUser);
@@ -69,8 +69,13 @@ class AuthenticationService {
   ///
   /// Throws an [AuthenticationException] if the sign-out process fails.
   Future<void> signOut() async {
-    // TODO: Implement sign out
-    throw UnimplementedError();
+    try {
+      await _firebaseAuth.signOut();
+    } on FirebaseAuthException catch (e) {
+      throw AuthenticationException.fromFirebaseAuthException(e);
+    } catch (_) {
+      rethrow;
+    }
   }
 }
 
@@ -95,8 +100,6 @@ sealed class AuthenticationException implements Exception {
     }
   }
 }
-
-class UnauthorizedException extends AuthenticationException {}
 
 class UserNotFoundException extends AuthenticationException {}
 

--- a/lib/ui/constants/app_icons.dart
+++ b/lib/ui/constants/app_icons.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/material.dart';
+
+abstract base class AppIcons {
+  static const IconData singOut = Icons.logout;
+}

--- a/lib/ui/constants/app_texts.dart
+++ b/lib/ui/constants/app_texts.dart
@@ -10,7 +10,6 @@ abstract base class AppTexts {
       'Please enter a valid email address';
   static const String passwordMustBeAtLeast6Characters =
       'Password must be at least 6 characters long';
-  static const String unauthorizedAccess = 'Unauthorized access.';
   static const String userNotFound = 'User not found.';
   static const String wrongEmailOrPassword = 'Wrong email or password.';
   static const String emailAlreadyInUse = 'Email is already in use.';

--- a/lib/ui/pages/home_page.dart
+++ b/lib/ui/pages/home_page.dart
@@ -1,13 +1,55 @@
-import 'package:flutter/material.dart';
-import 'package:quizlet_clone/ui/constants/app_texts.dart';
+import 'dart:async';
 
-class HomePage extends StatelessWidget {
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:quizlet_clone/bloc/authentication_bloc/authentication_bloc.dart';
+import 'package:quizlet_clone/ui/constants/app_icons.dart';
+import 'package:quizlet_clone/ui/constants/app_texts.dart';
+import 'package:quizlet_clone/ui/router/app_router.dart';
+
+class HomePage extends StatefulWidget {
   const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  late final AuthenticationBloc _authenticationBloc;
+
+  @override
+  void initState() {
+    super.initState();
+    _authenticationBloc = context.read<AuthenticationBloc>()
+      ..addListener(
+        _authenticationStatusListener,
+      );
+  }
+
+  @override
+  void dispose() {
+    if (mounted) {
+      _authenticationBloc.removeListener(_authenticationStatusListener);
+    }
+    super.dispose();
+  }
+
+  void _authenticationStatusListener() {
+    if (!_authenticationBloc.state.isAuthenticated) {
+      unawaited(Navigator.of(context).pushReplacementNamed(RouteNames.signUp));
+    }
+  }
 
   @override
   Widget build(BuildContext context) => Scaffold(
         appBar: AppBar(
           title: const Text(AppTexts.appName),
+          actions: [
+            IconButton(
+              icon: const Icon(AppIcons.singOut),
+              onPressed: () => unawaited(_authenticationBloc.signOut()),
+            )
+          ],
         ),
         body: const Center(
           child: Text(AppTexts.appName),


### PR DESCRIPTION
The changes introduce a sign-out functionality integrated into the UI of the application.

#### Key Changes:
-  The `HomePage` class is refactored from a `StatelessWidget` to a `StatefulWidget` to manage the authentication state. An `AuthenticationBloc` is used to listen for authentication status changes, and a sign-out button is added to the app bar. When the user signs out, the app navigates to the sign-up page.

- In the `AuthenticationBloc`, the initial state is changed from `AuthenticationInitial` to `AuthenticationUnauthenticated`, and the `signOut` method is implemented to handle the sign-out process, updating the state accordingly and notifying listeners.

- The `AuthenticationService` is updated to return `null` instead of throwing an `UnauthorizedException` when no user is authenticated, and the `signOut` method is implemented to handle Firebase sign-out, throwing an `AuthenticationException` if it fails.

- A new `AppIcons` class is introduced to manage app icons, including the new sign-out icon.

---

#### Video Preview

https://github.com/user-attachments/assets/fd6be1df-06d3-46de-990b-5e00a4eed777

