### PR TITLE
Feat/quizlet 7/create

### DIFF
--- a/lib/bloc/create_bloc/create_flash_card_set_form_bloc.dart
+++ b/lib/bloc/create_bloc/create_flash_card_set_form_bloc.dart
@@ -1,0 +1,31 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/material.dart';
+import 'package:quizlet_clone/bloc/create_bloc/create_flash_card_set_form_bloc_state.dart';
+import 'package:quizlet_clone/data/flash_card_set_service.dart';
+
+class CreateFlashCardSetFormBloc extends ChangeNotifier {
+  CreateFlashCardSetFormBloc(this._flashCardSetService);
+
+  CreateFlashCardSetFormBlocState _state = CreateFlashCardInitialState();
+
+  final FlashCardSetService _flashCardSetService;
+
+  CreateFlashCardSetFormBlocState get state => _state;
+
+  Future<void> createFlashCardSet(
+      {required String name, required String colorHex}) async {
+    _state = CreateFlashCardLoadingState();
+    notifyListeners();
+    try {
+      final flashCardSetAdded = await _flashCardSetService.createFlashCardSet(
+        name: name,
+        colorHex: colorHex,
+      );
+      _state = CreateFlashCardSuccessState(flashCardSetAdded);
+    } on FirebaseException catch (error) {
+      throw FlashCardSetServiceException.fromFirebaseException(error);
+    } finally {
+      notifyListeners();
+    }
+  }
+}

--- a/lib/bloc/create_bloc/create_flash_card_set_form_bloc_state.dart
+++ b/lib/bloc/create_bloc/create_flash_card_set_form_bloc_state.dart
@@ -1,0 +1,36 @@
+import 'package:quizlet_clone/data/flash_card_set_service.dart';
+import 'package:quizlet_clone/models/flash_card_set.dart';
+import 'package:quizlet_clone/ui/constants/app_texts.dart';
+
+sealed class CreateFlashCardSetFormBlocState {
+  bool get isSuccessful => this is CreateFlashCardSuccessState;
+
+  bool get isLoading => this is CreateFlashCardLoadingState;
+}
+
+class CreateFlashCardInitialState extends CreateFlashCardSetFormBlocState{}
+
+class CreateFlashCardLoadingState extends CreateFlashCardSetFormBlocState{}
+
+class CreateFlashCardSuccessState extends CreateFlashCardSetFormBlocState{
+  CreateFlashCardSuccessState(this.flashCardSet);
+
+  final FlashCardSet flashCardSet;
+}
+
+class CreateFlashCardErrorState extends CreateFlashCardSetFormBlocState{
+  CreateFlashCardErrorState(this.error);
+
+  final FlashCardSetServiceException error;
+
+  String get errorMessage {
+    switch (error) {
+      case InsufficientPermissionException():
+        return AppTexts.insufficientPermission;
+      case InternalErrorException():
+        return AppTexts.internalError;
+      case GenericFirestoreException():
+        return AppTexts.unknownError;
+    }
+  }
+}

--- a/lib/data/flash_card_set_service.dart
+++ b/lib/data/flash_card_set_service.dart
@@ -20,6 +20,27 @@ class FlashCardSetService {
       rethrow;
     }
   }
+
+  Future<FlashCardSet> createFlashCardSet({
+    required String name,
+    required String colorHex,
+  }) async {
+    try {
+      final addedFlashCard = await _fireStore.collection('flashcard-sets').add({
+        'name': name,
+        'color': colorHex,
+      });
+      final retrievedFlashCard = await addedFlashCard.get();
+      return FlashCardSet(
+        name: retrievedFlashCard['name'].toString(),
+        colorHex: retrievedFlashCard['color'].toString(),
+      );
+    } on FirebaseException catch (error) {
+      throw FlashCardSetServiceException.fromFirebaseException(error);
+    } catch (error) {
+      rethrow;
+    }
+  }
 }
 
 //Class for handling Firestore related exceptions

--- a/lib/data/flash_card_set_service.dart
+++ b/lib/data/flash_card_set_service.dart
@@ -31,10 +31,14 @@ class FlashCardSetService {
         'color': colorHex,
       });
       final retrievedFlashCard = await addedFlashCard.get();
+      if(!retrievedFlashCard.exists){
+        throw GenericFirestoreException();
+      } else{
       return FlashCardSet(
         name: retrievedFlashCard['name'].toString(),
         colorHex: retrievedFlashCard['color'].toString(),
       );
+    }
     } on FirebaseException catch (error) {
       throw FlashCardSetServiceException.fromFirebaseException(error);
     } catch (error) {

--- a/lib/ui/constants/app_icons.dart
+++ b/lib/ui/constants/app_icons.dart
@@ -2,4 +2,6 @@ import 'package:flutter/material.dart';
 
 abstract base class AppIcons {
   static const IconData singOut = Icons.logout;
+  static const IconData add = Icons.add;
+  static const IconData back = Icons.arrow_back;
 }

--- a/lib/ui/constants/app_texts.dart
+++ b/lib/ui/constants/app_texts.dart
@@ -21,4 +21,5 @@ abstract base class AppTexts {
   static const String signInSuccess = 'Signed in successfully';
   static const String insufficientPermission = 'Access denied';
   static const String internalError = 'An error has ocurred on the server';
+  static const String createSuccess = 'Flashcard successfully added!';
 }

--- a/lib/ui/pages/create_flash_card_page.dart
+++ b/lib/ui/pages/create_flash_card_page.dart
@@ -1,37 +1,102 @@
-import 'package:flutter/material.dart';
-import 'package:quizlet_clone/ui/widgets/forms/create_flash_card_set_form.dart';
+import 'dart:async';
 
-class CreateFlashCardPage extends StatelessWidget {
-  CreateFlashCardPage({super.key});
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:quizlet_clone/bloc/create_bloc/create_flash_card_set_form_bloc.dart';
+import 'package:quizlet_clone/bloc/create_bloc/create_flash_card_set_form_bloc_state.dart';
+import 'package:quizlet_clone/ui/constants/app_texts.dart';
+import 'package:quizlet_clone/ui/router/app_router.dart';
+import 'package:quizlet_clone/ui/utils/show_app_snack_bar.dart';
+import 'package:quizlet_clone/ui/widgets/forms/create_flash_card_set_form.dart';
+import 'package:quizlet_clone/ui/widgets/loading_overlay.dart';
+
+class CreateFlashCardPage extends StatefulWidget {
+  const CreateFlashCardPage({super.key});
+
+  @override
+  State<CreateFlashCardPage> createState() => _CreateFlashCardPageState();
+}
+
+class _CreateFlashCardPageState extends State<CreateFlashCardPage> {
+  late final CreateFlashCardSetFormBloc _createFlashCardBloc;
 
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _colorHexController = TextEditingController();
 
   @override
-  Widget build(BuildContext context) => Scaffold(
-        appBar: AppBar(
-          title: const Text('Create Flash Card'),
-        ),
-        body: ListView(
-          padding: const EdgeInsets.all(16),
-          children: [
-            CreateFlashCardSetForm(
-              formKey: _formKey,
-              nameController: _nameController,
-              nameValidator: _validateName,
+  void initState() {
+    super.initState();
+    _createFlashCardBloc = context.read<CreateFlashCardSetFormBloc>()//Error with Provider
+      ..addListener(createFlashCardStatusListener);
+  }
+
+  @override
+  void dispose() {
+    _createFlashCardBloc.removeListener(createFlashCardStatusListener);
+    _nameController.dispose();
+    _colorHexController.dispose();
+    super.dispose();
+  }
+
+  void createFlashCardStatusListener() {
+    switch (_createFlashCardBloc.state) {
+      case CreateFlashCardSuccessState _:
+        showAppSnackBar(
+          context,
+          message: AppTexts.createSuccess,
+          status: SnackBarStatus.success,
+        );
+        unawaited(Navigator.of(context).pushReplacementNamed(RouteNames.home));
+      case CreateFlashCardErrorState errorState:
+        showAppSnackBar(
+          context,
+          message: errorState.errorMessage,
+          status: SnackBarStatus.error,
+        );
+      default:
+        break;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) => Consumer<CreateFlashCardSetFormBloc>(
+        builder: (context, bloc, _) => LoadingOverlay(
+          isLoading: bloc.state.isLoading,
+          canPop: !bloc.state.isLoading,
+          child: Scaffold(
+            appBar: AppBar(
+              title: const Text('Create Flash Card'),
             ),
-            const SizedBox(height: 20),
-            TextButton(
-              onPressed: () {
-                if (_formKey.currentState!.validate()) {
-                  return;
-                }
-              },
-              child: const Text('Create'),
+            body: ListView(
+              padding: const EdgeInsets.all(16),
+              children: [
+                CreateFlashCardSetForm(
+                  formKey: _formKey,
+                  nameController: _nameController,
+                  nameValidator: _validateName,
+                  colorHex: _colorHexController,
+                ),
+                const SizedBox(height: 20),
+                TextButton(
+                  onPressed: onCreatePressed,
+                  child: const Text('Create'),
+                ),
+              ],
             ),
-          ],
+          ),
         ),
       );
+  void onCreatePressed() {
+    if (_formKey.currentState?.validate() ?? false) {
+      unawaited(
+        _createFlashCardBloc.createFlashCardSet(
+          name: _nameController.text,
+          colorHex: _colorHexController.text,
+        ),
+      );
+    }
+  }
 }
 
 String? _validateName(String? value) {

--- a/lib/ui/pages/create_flash_card_page.dart
+++ b/lib/ui/pages/create_flash_card_page.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:quizlet_clone/ui/widgets/forms/create_flash_card_set_form.dart';
+
+class CreateFlashCardPage extends StatelessWidget {
+  CreateFlashCardPage({super.key});
+
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final TextEditingController _nameController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        appBar: AppBar(
+          title: const Text('Create Flash Card'),
+        ),
+        body: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            CreateFlashCardSetForm(
+                formKey: _formKey, nameController: _nameController),
+            TextButton(
+              onPressed: (){
+                //TODO: Save entered card's data to Firebase
+              },
+              child: const Text('Create'),
+            ),
+          ],
+        ),
+      );
+}

--- a/lib/ui/pages/create_flash_card_page.dart
+++ b/lib/ui/pages/create_flash_card_page.dart
@@ -16,14 +16,27 @@ class CreateFlashCardPage extends StatelessWidget {
           padding: const EdgeInsets.all(16),
           children: [
             CreateFlashCardSetForm(
-                formKey: _formKey, nameController: _nameController),
+              formKey: _formKey,
+              nameController: _nameController,
+              nameValidator: _validateName,
+            ),
+            const SizedBox(height: 20),
             TextButton(
-              onPressed: (){
-                //TODO: Save entered card's data to Firebase
+              onPressed: () {
+                if (_formKey.currentState!.validate()) {
+                  return;
+                }
               },
               child: const Text('Create'),
             ),
           ],
         ),
       );
+}
+
+String? _validateName(String? value) {
+  if (value == null || value.isEmpty) {
+    return 'Please enter a name';
+  }
+  return null;
 }

--- a/lib/ui/pages/home_page.dart
+++ b/lib/ui/pages/home_page.dart
@@ -3,7 +3,9 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:quizlet_clone/bloc/authentication_bloc/authentication_bloc.dart';
+import 'package:quizlet_clone/bloc/create_bloc/create_flash_card_set_form_bloc.dart';
 import 'package:quizlet_clone/bloc/flash_card_set_list_bloc.dart';
+import 'package:quizlet_clone/data/flash_card_set_service.dart';
 import 'package:quizlet_clone/ui/constants/app_icons.dart';
 import 'package:quizlet_clone/ui/constants/app_texts.dart';
 import 'package:quizlet_clone/ui/pages/create_flash_card_page.dart';
@@ -65,7 +67,10 @@ class _HomePageState extends State<HomePage> {
             onPressed: () {
               unawaited(Navigator.of(context).push(
                 MaterialPageRoute(
-                  builder: (context) => CreateFlashCardPage(),
+                  builder: (context) => ChangeNotifierProvider(
+                    create: (_) => CreateFlashCardSetFormBloc(FlashCardSetService()),
+                    child: CreateFlashCardPage(),
+                  ),
                 ),
               ));
             },

--- a/lib/ui/pages/home_page.dart
+++ b/lib/ui/pages/home_page.dart
@@ -6,6 +6,7 @@ import 'package:quizlet_clone/bloc/authentication_bloc/authentication_bloc.dart'
 import 'package:quizlet_clone/bloc/flash_card_set_list_bloc.dart';
 import 'package:quizlet_clone/ui/constants/app_icons.dart';
 import 'package:quizlet_clone/ui/constants/app_texts.dart';
+import 'package:quizlet_clone/ui/pages/create_flash_card_page.dart';
 import 'package:quizlet_clone/ui/router/app_router.dart';
 import 'package:quizlet_clone/ui/widgets/flash_card_set_list.dart';
 
@@ -27,8 +28,8 @@ class _HomePageState extends State<HomePage> {
       ..addListener(
         _authenticationStatusListener,
       );
-      _flashCardListBloc = FlashCardSetListBloc();
-      _flashCardListBloc.getFlashCardSets();
+    _flashCardListBloc = FlashCardSetListBloc();
+    _flashCardListBloc.getFlashCardSets();
   }
 
   @override
@@ -47,8 +48,8 @@ class _HomePageState extends State<HomePage> {
 
   @override
   Widget build(BuildContext context) => ChangeNotifierProvider(
-    create: (_) => _flashCardListBloc,
-    child: Scaffold(
+        create: (_) => _flashCardListBloc,
+        child: Scaffold(
           appBar: AppBar(
             title: const Text(AppTexts.appName),
             actions: [
@@ -59,6 +60,16 @@ class _HomePageState extends State<HomePage> {
             ],
           ),
           body: FlashCardSetList(),
+          floatingActionButton: FloatingActionButton(
+            child: const Icon(AppIcons.add),
+            onPressed: () {
+              unawaited(Navigator.of(context).push(
+                MaterialPageRoute(
+                  builder: (context) => CreateFlashCardPage(),
+                ),
+              ));
+            },
+          ),
         ),
-  );
+      );
 }

--- a/lib/ui/pages/sign_in_page.dart
+++ b/lib/ui/pages/sign_in_page.dart
@@ -52,7 +52,6 @@ class _SignInPageState extends State<SignInPage> {
         );
         unawaited(Navigator.of(context).pushReplacementNamed(RouteNames.home));
       case AuthenticationError errorState:
-        print('Error from sign_in_page: ${errorState.error}');
         showAppSnackBar(
           context,
           message: errorState.errorMessage,

--- a/lib/ui/widgets/flash_card_set_list_tile.dart
+++ b/lib/ui/widgets/flash_card_set_list_tile.dart
@@ -1,3 +1,4 @@
+import 'package:color_hex/color_hex.dart';
 import 'package:flutter/material.dart';
 
 //Presents a tile of Flashcard from the the Flashcard Set
@@ -17,7 +18,7 @@ class FlashCardSetListTile extends StatelessWidget {
   Widget build(BuildContext context) => ListTile(
       title: Text(name),
       leading: CircleAvatar(
-        backgroundColor: hexToColor(colorHex),
+        backgroundColor: colorHex.convertToColor,
       )
     );
 }

--- a/lib/ui/widgets/forms/create_flash_card_set_form.dart
+++ b/lib/ui/widgets/forms/create_flash_card_set_form.dart
@@ -5,6 +5,7 @@ import 'package:quizlet_clone/ui/widgets/forms/form_fields/flash_card_name_form.
 class CreateFlashCardSetForm extends StatelessWidget {
   const CreateFlashCardSetForm({
     required this.formKey,
+    required this.colorHex,
     required this.nameController,
     super.key,
     this.nameValidator,
@@ -13,6 +14,8 @@ class CreateFlashCardSetForm extends StatelessWidget {
   final GlobalKey<FormState> formKey;
 
   final TextEditingController nameController;
+
+  final TextEditingController colorHex;
 
   final FormFieldValidator<String>? nameValidator;
 
@@ -27,7 +30,7 @@ class CreateFlashCardSetForm extends StatelessWidget {
               validator: nameValidator,
             ),
             const SizedBox(height: 16),
-            const ColorPickerForm(),
+            ColorPickerForm(colorHex: colorHex,),
           ],
         ),
       ));

--- a/lib/ui/widgets/forms/create_flash_card_set_form.dart
+++ b/lib/ui/widgets/forms/create_flash_card_set_form.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:quizlet_clone/ui/widgets/forms/form_fields/color_picker_form.dart';
 import 'package:quizlet_clone/ui/widgets/forms/form_fields/flash_card_name_form.dart';
 
 class CreateFlashCardSetForm extends StatelessWidget {
@@ -6,14 +7,14 @@ class CreateFlashCardSetForm extends StatelessWidget {
     required this.formKey,
     required this.nameController,
     super.key,
-    this.validator,
+    this.nameValidator,
   });
 
   final GlobalKey<FormState> formKey;
 
   final TextEditingController nameController;
 
-  final FormFieldValidator<String>? validator;
+  final FormFieldValidator<String>? nameValidator;
 
   @override
   Widget build(BuildContext context) => Form(
@@ -23,8 +24,10 @@ class CreateFlashCardSetForm extends StatelessWidget {
           children: [
             FlashCardNameForm(
               nameController: nameController,
-              validator: validator,
+              validator: nameValidator,
             ),
+            const SizedBox(height: 16),
+            const ColorPickerForm(),
           ],
         ),
       ));

--- a/lib/ui/widgets/forms/create_flash_card_set_form.dart
+++ b/lib/ui/widgets/forms/create_flash_card_set_form.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:quizlet_clone/ui/widgets/forms/form_fields/flash_card_name_form.dart';
+
+class CreateFlashCardSetForm extends StatelessWidget {
+  const CreateFlashCardSetForm({
+    required this.formKey,
+    required this.nameController,
+    super.key,
+    this.validator,
+  });
+
+  final GlobalKey<FormState> formKey;
+
+  final TextEditingController nameController;
+
+  final FormFieldValidator<String>? validator;
+
+  @override
+  Widget build(BuildContext context) => Form(
+      key: formKey,
+      child: Center(
+        child: Column(
+          children: [
+            FlashCardNameForm(
+              nameController: nameController,
+              validator: validator,
+            ),
+          ],
+        ),
+      ));
+}

--- a/lib/ui/widgets/forms/form_fields/color_picker_form.dart
+++ b/lib/ui/widgets/forms/form_fields/color_picker_form.dart
@@ -1,3 +1,4 @@
+import 'package:color_hex/color_hex.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 
@@ -14,7 +15,10 @@ class _ColorPickerFormState extends State<ColorPickerForm> {
   Color _currentColor = Colors.black;
 
   void _changeColor(Color color) {
-    setState(() => _currentColor = color);
+    setState((){
+      _currentColor = color;
+      widget.colorHex.text = color.convertToHex.hex!;
+    });
   }
 
   void _openColorPicker() {
@@ -32,7 +36,6 @@ class _ColorPickerFormState extends State<ColorPickerForm> {
           ElevatedButton(
         child: const Text('Done!'),
         onPressed: () {
-          _currentColor = _currentColor;
           Navigator.of(context).pop();
         },
       ),

--- a/lib/ui/widgets/forms/form_fields/color_picker_form.dart
+++ b/lib/ui/widgets/forms/form_fields/color_picker_form.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 
 class ColorPickerForm extends StatefulWidget {
-  const ColorPickerForm({super.key});
+  const ColorPickerForm({required this.colorHex, super.key});
+
+  final TextEditingController colorHex;
 
   @override
   State<ColorPickerForm> createState() => _ColorPickerFormState();

--- a/lib/ui/widgets/forms/form_fields/color_picker_form.dart
+++ b/lib/ui/widgets/forms/form_fields/color_picker_form.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_colorpicker/flutter_colorpicker.dart';
+
+class ColorPickerForm extends StatefulWidget {
+  const ColorPickerForm({super.key});
+
+  @override
+  State<ColorPickerForm> createState() => _ColorPickerFormState();
+}
+
+class _ColorPickerFormState extends State<ColorPickerForm> {
+  Color _currentColor = Colors.black;
+
+  void _changeColor(Color color) {
+    setState(() => _currentColor = color);
+  }
+
+  void _openColorPicker() {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Pick a color!'),
+        content: SingleChildScrollView(
+          child: ColorPicker(
+            pickerColor: _currentColor,
+            onColorChanged: _changeColor,
+          ),
+        ),
+        actions: <Widget>[
+          ElevatedButton(
+        child: const Text('Done!'),
+        onPressed: () {
+          _currentColor = _currentColor;
+          Navigator.of(context).pop();
+        },
+      ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) => InkWell(
+      onTap: _openColorPicker,
+      child: CircleAvatar(
+        backgroundColor: _currentColor,
+      )
+    );
+}

--- a/lib/ui/widgets/forms/form_fields/flash_card_name_form.dart
+++ b/lib/ui/widgets/forms/form_fields/flash_card_name_form.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class FlashCardNameForm extends StatelessWidget{
+  const FlashCardNameForm({required this.nameController, super.key, this.validator});
+
+  final TextEditingController nameController;
+  final FormFieldValidator<String>? validator;
+
+  @override
+  Widget build(BuildContext context) => TextFormField(
+      controller: nameController,
+      decoration: const InputDecoration(labelText: 'Name'),
+      validator: validator,
+      textInputAction: TextInputAction.next,
+      autovalidateMode: AutovalidateMode.onUserInteraction,
+    );
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -134,6 +134,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_colorpicker:
+    dependency: "direct main"
+    description:
+      name: flutter_colorpicker
+      sha256: "969de5f6f9e2a570ac660fb7b501551451ea2a1ab9e2097e89475f60e07816ea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -73,6 +73,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.0"
+  color_hex:
+    dependency: "direct main"
+    description:
+      name: color_hex
+      sha256: f19befdf0afe8d67ee1ec1f4038da80a7b9e0876167cf017b0b86d56b415f698
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.1"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   cloud_firestore: ^5.6.1
+  color_hex: ^0.0.1
   firebase_auth: ^5.3.4
   firebase_core: ^3.9.0
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   firebase_core: ^3.9.0
   flutter:
     sdk: flutter
+  flutter_colorpicker: ^1.1.0
   provider: ^6.1.2
 
 dev_dependencies:


### PR DESCRIPTION
### **User description**
This branch added a separate page for creating a Flashcard by adding new item to Firestore


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added functionality to create flashcard sets with name and color.

- Implemented Bloc and state management for flashcard creation.

- Integrated a color picker for selecting flashcard set colors.

- Updated UI with a new page for creating flashcards and navigation enhancements.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>11 files</summary><table>
<tr>
  <td><strong>create_flash_card_set_form_bloc.dart</strong><dd><code>Added Bloc for flashcard set creation logic.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/16/files#diff-57261f6edbb9d1f7d52eec7454e0b153d4de04eb44b92037ab6d8e3ec052af14">+31/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>create_flash_card_set_form_bloc_state.dart</strong><dd><code>Added state management for flashcard creation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/16/files#diff-96428da16adaab83daeb80ab8c274073c7bb3a4fc0d57a87528404273eae6944">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flash_card_set_service.dart</strong><dd><code>Added service method for creating flashcard sets in Firestore.</code></dd></td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/16/files#diff-dc2ff81338b87123d0e69706b0966f10c9657c6279972144ef78c8c802a2dcdd">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app_icons.dart</strong><dd><code>Added new icons for UI enhancements.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/16/files#diff-f8d9d93c1830f45fbc5826255654113db6dcf5c753b82113ef4225ff6bffe0f3">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app_texts.dart</strong><dd><code>Added new text constants for flashcard creation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/16/files#diff-2060d60c5bcac0dac733bc1fa231f0454e0275ec7b1d052250be2b589af56368">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>create_flash_card_page.dart</strong><dd><code>Created a new page for flashcard creation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/16/files#diff-8a39500003360b3ccefa3de1ce0dab474c5e7db4ca3c382ad836f3a8471fda7f">+107/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>home_page.dart</strong><dd><code>Added navigation to flashcard creation page.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/16/files#diff-646ff82d55407a5c6068a3b59da1b553f5ef7a676b04a26b99db9179dab68559">+21/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flash_card_set_list_tile.dart</strong><dd><code>Updated flashcard list tile to use color picker.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/16/files#diff-27b5a2828775fdabaf03da9332585bff1d3007cdc92404c5b31e7c9337ec22d4">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>create_flash_card_set_form.dart</strong><dd><code>Added form widget for flashcard set creation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/16/files#diff-893df056a0b27dcec806a3699c9f36abf365f695a2d90d0b9720d167c721690f">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>color_picker_form.dart</strong><dd><code>Added color picker form field for flashcard creation.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/16/files#diff-3ddf2f0988105ac4444a6304aa4ac9a8b0b42583a5c3ecd8b5352f78f34df49d">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flash_card_name_form.dart</strong><dd><code>Added name input form field for flashcard creation.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/16/files#diff-3d68953bf24a9005222ea22ea35a768f16c53c6e84ebfee88d21bd0519d5e12e">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>sign_in_page.dart</strong><dd><code>Removed debug print statements for error handling.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/16/files#diff-dbfa4763ae1f14cf4884e6b612a40fa8d04a958203522ec05863869960edb485">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>pubspec.yaml</strong><dd><code>Added dependencies for color picker and hex color handling.</code></dd></td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/16/files#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>