### PR TITLE
Enhancement: Delete Flashcard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ app.*.map.json
 
 # FVM Version Cache
 .fvm/
+.qodo

--- a/lib/bloc/flashcard_list_bloc/flashcard_list_bloc.dart
+++ b/lib/bloc/flashcard_list_bloc/flashcard_list_bloc.dart
@@ -2,7 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:quizlet_clone/bloc/flashcard_list_bloc/flashcard_list_bloc_state.dart';
 import 'package:quizlet_clone/data/flashcard_service.dart';
 
-class FlashCardListBloc extends ChangeNotifier{
+class FlashCardListBloc extends ChangeNotifier {
   FlashCardListBloc(this._flashCardService);
 
   FlashCardListState _state = FlashCardListInitialState();
@@ -11,16 +11,52 @@ class FlashCardListBloc extends ChangeNotifier{
 
   final FlashCardService _flashCardService;
 
-  Future<void> getFlashcards(final String flashCardSetid) async{
+  Future<void> getFlashcards(final String flashCardSetid) async {
     _state = FlashCardListLoadingState();
     notifyListeners();
 
-    try{
-      final flashCardsReceived = await _flashCardService.getFlashcards(flashCardSetid);
-      _state = FlashCardListSuccessState(flashCardsReceived);
-    } on FlashCardServiceException catch(e){
+    try {
+      final flashCardsReceived =
+          await _flashCardService.getFlashcards(flashCardSetid);
+      _state = FlashCardListSuccessState(flashcards: flashCardsReceived);
+    } on FlashCardServiceException catch (e) {
       _state = FlashCardListErrorState(e);
-    } finally{
+    } finally {
+      notifyListeners();
+    }
+  }
+
+  Future<void> deleteFlashcardById(
+    final String question,
+    final String answer,
+    final String flashcardSetId,
+    final String flashcardId,
+  ) async {
+    final cachedSuccessState = _state as FlashCardListSuccessState;
+    _state = FlashCardListLoadingState();
+    notifyListeners();
+
+    try {
+      await _flashCardService.deleteFlashcardById(
+        question: question,
+        answer: answer,
+        flashcardSetId: flashcardSetId,
+        flashcardId: flashcardId,
+      );
+      final flashcardReceived =
+          await _flashCardService.getFlashcards(flashcardSetId);
+      _state = FlashCardListSuccessState(
+        flashcards: flashcardReceived,
+        isFirstLoad: false,
+        //the get flashcard method is used again, which means it is not the first load
+      );
+    } on FlashCardServiceException catch (e) {
+      _state = FlashCardListSuccessState(
+        flashcards: cachedSuccessState.flashcards,
+        isFirstLoad: false,
+        deletionError: e,
+      );
+    } finally {
       notifyListeners();
     }
   }

--- a/lib/bloc/flashcard_list_bloc/flashcard_list_bloc_state.dart
+++ b/lib/bloc/flashcard_list_bloc/flashcard_list_bloc_state.dart
@@ -13,8 +13,10 @@ class FlashCardListInitialState extends FlashCardListState {}
 class FlashCardListLoadingState extends FlashCardListState {}
 
 class FlashCardListSuccessState extends FlashCardListState{
-  FlashCardListSuccessState(this.flashcards);
+  FlashCardListSuccessState({required this.flashcards, this.isFirstLoad = true, this.deletionError});
   final List<Flashcard> flashcards;
+  final bool isFirstLoad;
+  final FlashCardServiceException? deletionError;
 }
 
 class FlashCardListErrorState extends FlashCardListState {

--- a/lib/data/flash_card_set_service.dart
+++ b/lib/data/flash_card_set_service.dart
@@ -88,6 +88,11 @@ class FlashCardSetService {
       if(flashCardId.isEmpty){
         throw ArgumentError('Flashcard ID is empty!');
       }
+      var flashcardsCollection = collection.doc(flashCardId).collection('flashcards');
+      var flashcardsSnapshot = await flashcardsCollection.get();
+      for(final doc in flashcardsSnapshot.docs){
+        await doc.reference.delete();
+      }
       await collection.doc(flashCardId).delete();
       return FlashCardSet(
         name: name,

--- a/lib/data/flashcard_service.dart
+++ b/lib/data/flashcard_service.dart
@@ -78,6 +78,26 @@ class FlashCardService {
       rethrow;
     }
   }
+
+  Future<Flashcard> deleteFlashcardById({
+    required String question,
+    required String answer,
+    required String flashcardSetId,
+    required String flashcardId,
+  }) async {
+    try{
+      var flashcardCollection = _fireStore
+        .collection('flashcard-sets')
+        .doc(flashcardSetId)
+        .collection('flashcards');
+    await flashcardCollection.doc(flashcardId).delete();
+    return Flashcard(id: flashcardSetId, question: question, answer: answer);
+    } on FirebaseException catch (error) {
+      throw FlashCardServiceException.fromFirebaseException(error);
+    } catch (error) {
+      rethrow;
+    }
+  }
 }
 
 sealed class FlashCardServiceException implements Exception {

--- a/lib/models/flashcard.dart
+++ b/lib/models/flashcard.dart
@@ -4,7 +4,7 @@ class Flashcard {
     required this.question,
     required this.answer,
   });
-  final String id;
+  final String id;//id of the set it belongs to aka FlashcardSetId
   final String question;
   final String answer;
 }

--- a/lib/ui/constants/app_texts.dart
+++ b/lib/ui/constants/app_texts.dart
@@ -30,4 +30,6 @@ abstract base class AppTexts {
   static const String flashCardSetEmpty = 'No flashcards found in this set';
   static const String createFlashcardSuccess = 'Flashcard successfully created';
   static const String editFlashcardSuccess = 'Flashcard successfully edited';
+  static const String deleteByIdSuccess = 'Flashcard successfully deleted';
+  static const String deleteByIdError = 'Flashcard could not be deleted';
 }

--- a/lib/ui/widgets/flashcard_list.dart
+++ b/lib/ui/widgets/flashcard_list.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:quizlet_clone/bloc/flashcard_list_bloc/flashcard_list_bloc.dart';
 import 'package:quizlet_clone/bloc/flashcard_list_bloc/flashcard_list_bloc_state.dart';
 import 'package:quizlet_clone/ui/constants/app_texts.dart';
+import 'package:quizlet_clone/ui/utils/show_app_snack_bar.dart';
 import 'package:quizlet_clone/ui/widgets/flashcard_list_tile.dart';
 
 class FlashcardList extends StatefulWidget {
@@ -14,6 +17,47 @@ class FlashcardList extends StatefulWidget {
 }
 
 class _FlashcardListState extends State<FlashcardList> {
+  late final FlashCardListBloc _flashCardListBloc;
+
+  @override
+  void initState() {
+    super.initState();
+    _flashCardListBloc = context.read<FlashCardListBloc>()
+      ..addListener(_flashcardBlocDeletionStatusListener);
+  }
+
+  @override
+  void dispose() {
+    _flashCardListBloc.removeListener(_flashcardBlocDeletionStatusListener);
+    super.dispose();
+  }
+
+  void _flashcardBlocDeletionStatusListener() {
+    switch (_flashCardListBloc.state) {
+      case FlashCardListSuccessState flashCardListSuccessState:
+        if (flashCardListSuccessState.isFirstLoad) {
+          return;
+        }
+        final hasNoDeletionError =
+            flashCardListSuccessState.deletionError == null;
+        if (hasNoDeletionError) {
+          showAppSnackBar(
+            context,
+            message: AppTexts.deleteByIdSuccess,
+            status: SnackBarStatus.success,
+          );
+        } else {
+          showAppSnackBar(
+            context,
+            message: AppTexts.deleteByIdError,
+            status: SnackBarStatus.error,
+          );
+        }
+      default:
+        return;
+    }
+  }
+
   @override
   Widget build(BuildContext context) => Consumer<FlashCardListBloc>(
         builder: (_, bloc, __) {
@@ -28,13 +72,26 @@ class _FlashcardListState extends State<FlashcardList> {
                   ? const Center(child: Text(AppTexts.flashCardSetEmpty))
                   : ListView.builder(
                       itemCount: state.flashcards.length,
-                      itemBuilder: (context, index) => Card.outlined(
-                        color: Colors.green[50],
-                        child: FlashcardListTile(
-                          question: state.flashcards[index].question,
-                          answer: state.flashcards[index].answer,
-                          id: widget.flashCardSetId,
-                          flashCardId: state.flashcards[index].id,
+                      itemBuilder: (context, index) => Dismissible(
+                        key: Key(state.flashcards[index].id),
+                        onDismissed: (direction) {
+                          unawaited(
+                            _flashCardListBloc.deleteFlashcardById(
+                              state.flashcards[index].question,
+                              state.flashcards[index].answer,
+                              widget.flashCardSetId,
+                              state.flashcards[index].id,
+                            ),
+                          );
+                        },
+                        child: Card.outlined(
+                          color: Colors.green[50],
+                          child: FlashcardListTile(
+                            question: state.flashcards[index].question,
+                            answer: state.flashcards[index].answer,
+                            id: widget.flashCardSetId,
+                            flashCardId: state.flashcards[index].id,
+                          ),
                         ),
                       ),
                     );


### PR DESCRIPTION
### **User description**
1. Added new delete method in flashcard_service and flashcard_list_bloc;

2. Implemented delete method in flashcard_list, wrapping its ListTiles in Dismissible widget;

3. Added Snackbar to confirm deletion success/failure;

4. Now, when a FlashcardSet is deleted, all its flashcards are deleted as well;


https://github.com/user-attachments/assets/6216f876-d8fe-400d-a3ca-2683018c4f01


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added a delete method for flashcards in `flashcard_service` and `flashcard_list_bloc`.

- Enhanced `flashcard_list` UI with `Dismissible` for flashcard deletion.

- Introduced Snackbar notifications for deletion success or failure.

- Ensured cascading deletion of flashcards when a FlashcardSet is deleted.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td><strong>flashcard_list_bloc.dart</strong><dd><code>Added delete method and state management for flashcards</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/26/files#diff-2fce605adb28cb8c2be39fc20bef61b127dd0b335ed0e0f320285738c10e4727">+44/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flashcard_list_bloc_state.dart</strong><dd><code>Updated state to handle deletion feedback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/26/files#diff-2d33f8b56a4979335dc1cc0261084e221566d47ce19694adb2febc9d0c049dda">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flash_card_set_service.dart</strong><dd><code>Implemented cascading deletion of flashcards in a set</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/26/files#diff-dc2ff81338b87123d0e69706b0966f10c9657c6279972144ef78c8c802a2dcdd">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flashcard_service.dart</strong><dd><code>Added method to delete individual flashcards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/26/files#diff-24350442dd1d093581953f485fd4c1c4014856d3bacd15f8a41aca9ed923373d">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>app_texts.dart</strong><dd><code>Added constants for flashcard deletion messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/26/files#diff-2060d60c5bcac0dac733bc1fa231f0454e0275ec7b1d052250be2b589af56368">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>flashcard_list.dart</strong><dd><code>Integrated `Dismissible` and Snackbar for flashcard deletion</code></dd></td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/26/files#diff-4e4835551b019ba53f0c5abe5e3cc3f3f0a8bf1a1bd1fba1d89e73c0e87c5969">+64/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>flashcard.dart</strong><dd><code>Updated flashcard model with clarifying comments</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/26/files#diff-608ff325dca603d1cfed489c8a77a01353911bf9d483ac810ef417cd5efed7e9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>