### PR TITLE
Flashcard Color Enhancement:

### DIFF
--- a/lib/ui/pages/create_flashcard_page.dart
+++ b/lib/ui/pages/create_flashcard_page.dart
@@ -10,8 +10,9 @@ import 'package:quizlet_clone/ui/widgets/forms/flashcard_form.dart';
 import 'package:quizlet_clone/ui/widgets/loading_overlay.dart';
 
 class CreateFlashcardPage extends StatefulWidget {
-  const CreateFlashcardPage({required this.flashCardSetId, super.key});
+  const CreateFlashcardPage({required this.flashCardSetId, required this.flashCardColorHex, super.key});
   final String flashCardSetId;
+  final String flashCardColorHex;
 
   @override
   State<CreateFlashcardPage> createState() => _CreateFlashcardPageState();
@@ -53,6 +54,7 @@ class _CreateFlashcardPageState extends State<CreateFlashcardPage> {
             MaterialPageRoute(
               builder: (_) => FlashCardSetDetailPage(
                 flashCardSetid: widget.flashCardSetId,
+                flashCardColorHex: widget.flashCardColorHex,
               ),
             ),
           ),

--- a/lib/ui/pages/edit_flashcard_page.dart
+++ b/lib/ui/pages/edit_flashcard_page.dart
@@ -12,9 +12,10 @@ import 'package:quizlet_clone/ui/widgets/loading_overlay.dart';
 
 class EditFlashcardPage extends StatefulWidget {
   const EditFlashcardPage(
-      {required this.flashCardId, required this.flashCardSetId, super.key});
+      {required this.flashCardId, required this.flashCardSetId, required this.flashCardColorHex, super.key});
   final String flashCardId;
   final String flashCardSetId;
+  final String flashCardColorHex;
 
   @override
   State<EditFlashcardPage> createState() => _EditFlashcardPageState();
@@ -56,6 +57,7 @@ class _EditFlashcardPageState extends State<EditFlashcardPage> {
             MaterialPageRoute(
               builder: (_) => FlashCardSetDetailPage(
                 flashCardSetid: widget.flashCardSetId,
+                flashCardColorHex: widget.flashCardColorHex,
               ),
             ),
           ),

--- a/lib/ui/pages/flashcardset_detail_page.dart
+++ b/lib/ui/pages/flashcardset_detail_page.dart
@@ -9,9 +9,10 @@ import 'package:quizlet_clone/ui/pages/create_flashcard_page.dart';
 import 'package:quizlet_clone/ui/widgets/flashcard_list.dart';
 
 class FlashCardSetDetailPage extends StatefulWidget {
-  const FlashCardSetDetailPage({required this.flashCardSetid, super.key});
+  const FlashCardSetDetailPage({required this.flashCardSetid, required this.flashCardColorHex, super.key});
 
   final String flashCardSetid;
+  final String flashCardColorHex;
 
   @override
   State<FlashCardSetDetailPage> createState() => _FlashCardSetDetailPageState();
@@ -38,7 +39,7 @@ class _FlashCardSetDetailPageState extends State<FlashCardSetDetailPage> {
           appBar: AppBar(
             title: const Text('Flashcard Detail Page'),
           ),
-          body: FlashcardList(flashCardSetId: widget.flashCardSetid,),
+          body: FlashcardList(flashCardSetId: widget.flashCardSetid, flashCardColorHex: widget.flashCardColorHex,),
           floatingActionButton: FloatingActionButton(
             child: const Icon(Icons.add),
             onPressed: () {
@@ -47,7 +48,8 @@ class _FlashCardSetDetailPageState extends State<FlashCardSetDetailPage> {
                   builder: (context) => ChangeNotifierProvider(
                     create: (_) => CreateFlashcardFormBloc(FlashCardService()),
                     child: CreateFlashcardPage(
-                        flashCardSetId: widget.flashCardSetid),
+                        flashCardSetId: widget.flashCardSetid,
+                        flashCardColorHex: widget.flashCardColorHex,),
                   ),
                 ),
               ));

--- a/lib/ui/widgets/flash_card_set_list.dart
+++ b/lib/ui/widgets/flash_card_set_list.dart
@@ -94,6 +94,7 @@ class _FlashCardSetListState extends State<FlashCardSetList> {
                               create: (_) => FlashCardListBloc(FlashCardService()),
                               child: FlashCardSetDetailPage(
                                     flashCardSetid: state.flashCardSets[index].id,
+                                    flashCardColorHex: state.flashCardSets[index].colorHex,
                                   ),
                             )),
                       ),

--- a/lib/ui/widgets/flashcard_list.dart
+++ b/lib/ui/widgets/flashcard_list.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:color_hex/color_hex.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:quizlet_clone/bloc/flashcard_list_bloc/flashcard_list_bloc.dart';
@@ -9,8 +10,9 @@ import 'package:quizlet_clone/ui/utils/show_app_snack_bar.dart';
 import 'package:quizlet_clone/ui/widgets/flashcard_list_tile.dart';
 
 class FlashcardList extends StatefulWidget {
-  const FlashcardList({required this.flashCardSetId, super.key});
+  const FlashcardList({required this.flashCardSetId, required this.flashCardColorHex, super.key});
   final String flashCardSetId;
+  final String flashCardColorHex;
 
   @override
   State<FlashcardList> createState() => _FlashcardListState();
@@ -85,12 +87,13 @@ class _FlashcardListState extends State<FlashcardList> {
                           );
                         },
                         child: Card.outlined(
-                          color: Colors.green[50],
+                          color: widget.flashCardColorHex.convertToColor.withAlpha(50),
                           child: FlashcardListTile(
                             question: state.flashcards[index].question,
                             answer: state.flashcards[index].answer,
                             id: widget.flashCardSetId,
                             flashCardId: state.flashcards[index].id,
+                            flashCardColorHex: widget.flashCardColorHex,
                           ),
                         ),
                       ),

--- a/lib/ui/widgets/flashcard_list_tile.dart
+++ b/lib/ui/widgets/flashcard_list_tile.dart
@@ -12,6 +12,7 @@ class FlashcardListTile extends StatelessWidget {
     required this.answer,
     required this.id,
     required this.flashCardId,
+    required this.flashCardColorHex,
     super.key,
   });
 
@@ -19,6 +20,7 @@ class FlashcardListTile extends StatelessWidget {
   final String answer;
   final String id;
   final String flashCardId;
+  final String flashCardColorHex;
 
   @override
   Widget build(BuildContext context) => ListTile(
@@ -39,7 +41,8 @@ class FlashcardListTile extends StatelessWidget {
                       create: (_) => EditFlashcardFormBloc(FlashCardService()),
                       child: EditFlashcardPage(
                           flashCardId: flashCardId,
-                          flashCardSetId: id),
+                          flashCardSetId: id,
+                          flashCardColorHex: flashCardColorHex,),
                     ))));
           },
           icon: const Icon(Icons.edit),


### PR DESCRIPTION
### **User description**
Flashcard colors are now determined by the color of the FlashcardSet. The color of opacity of the flashcard is lowered to prevent black flashcards from being unreadable.


https://github.com/user-attachments/assets/d789b23d-cced-409a-b895-18a553adcc88


___

### **PR Type**
Enhancement


___

### **Description**
- Added `flashCardColorHex` parameter across multiple widgets for color customization.

- Updated flashcard background color using `flashCardColorHex` with opacity adjustment.

- Enhanced navigation to pass `flashCardColorHex` between pages and widgets.

- Improved flashcard readability by dynamically applying color adjustments.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>create_flashcard_page.dart</strong><dd><code>Add `flashCardColorHex` to `CreateFlashcardPage`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/ui/pages/create_flashcard_page.dart

<li>Added <code>flashCardColorHex</code> parameter to <code>CreateFlashcardPage</code>.<br> <li> Passed <code>flashCardColorHex</code> to <code>FlashCardSetDetailPage</code> during navigation.


</details>


  </td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/27/files#diff-7792e72954154d35a55b53a2744d3e2f9cdf0975a6686a307829c0516f388f06">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>edit_flashcard_page.dart</strong><dd><code>Add `flashCardColorHex` to `EditFlashcardPage`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/ui/pages/edit_flashcard_page.dart

<li>Added <code>flashCardColorHex</code> parameter to <code>EditFlashcardPage</code>.<br> <li> Passed <code>flashCardColorHex</code> to <code>FlashCardSetDetailPage</code> during navigation.


</details>


  </td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/27/files#diff-4c242383aa155c0e5b34b220929d97a2ad54b6c1c8642f20341c7474ca8b0edb">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>flashcardset_detail_page.dart</strong><dd><code>Add `flashCardColorHex` to `FlashCardSetDetailPage`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/ui/pages/flashcardset_detail_page.dart

<li>Added <code>flashCardColorHex</code> parameter to <code>FlashCardSetDetailPage</code>.<br> <li> Passed <code>flashCardColorHex</code> to <code>FlashcardList</code> and <code>CreateFlashcardPage</code>.


</details>


  </td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/27/files#diff-efacafb6e8d94671027cde97274f369fbad8912b0083722ff178dafae035b6db">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>flash_card_set_list.dart</strong><dd><code>Pass `flashCardColorHex` to `FlashCardSetDetailPage`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/ui/widgets/flash_card_set_list.dart

<li>Passed <code>flashCardColorHex</code> to <code>FlashCardSetDetailPage</code> during navigation.


</details>


  </td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/27/files#diff-15291701a77bb5c32bfd371baf748cd8dd3a3743bd06842206ff5b774701fc33">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>flashcard_list.dart</strong><dd><code>Add color customization to `FlashcardList`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/ui/widgets/flashcard_list.dart

<li>Added <code>flashCardColorHex</code> parameter to <code>FlashcardList</code>.<br> <li> Updated flashcard background color using <code>flashCardColorHex</code> with <br>opacity.


</details>


  </td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/27/files#diff-4e4835551b019ba53f0c5abe5e3cc3f3f0a8bf1a1bd1fba1d89e73c0e87c5969">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>flashcard_list_tile.dart</strong><dd><code>Add `flashCardColorHex` to `FlashcardListTile`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/ui/widgets/flashcard_list_tile.dart

<li>Added <code>flashCardColorHex</code> parameter to <code>FlashcardListTile</code>.<br> <li> Passed <code>flashCardColorHex</code> to <code>EditFlashcardPage</code> during navigation.


</details>


  </td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/27/files#diff-90cea662a3f991e3121fa224399293a063b78d74d7105f6a3ef6dbb94350d89f">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>