### PR TITLE
Fix: Bottom Overflow

### DIFF
--- a/lib/ui/pages/quiz_game_end_page.dart
+++ b/lib/ui/pages/quiz_game_end_page.dart
@@ -52,6 +52,7 @@ class _QuizGameEndPageState extends State<QuizGameEndPage> {
           title: const Text('Results'),
         ),
         body: SingleChildScrollView(
+          padding: const EdgeInsets.all(16),
           child: Column(
             spacing: 40,
             children: [
@@ -88,8 +89,8 @@ class _QuizGameEndPageState extends State<QuizGameEndPage> {
               ),
               Center(
                 child: SizedBox(
-                  height: 300,
-                  width: 300,
+                  height: MediaQuery.of(context).size.width*0.85,
+                  width: MediaQuery.of(context).size.width*0.85,
                   child: Image.asset(
                     resultImageFile(),
                     fit: BoxFit.contain,

--- a/lib/ui/pages/quiz_game_end_page.dart
+++ b/lib/ui/pages/quiz_game_end_page.dart
@@ -35,7 +35,7 @@ class _QuizGameEndPageState extends State<QuizGameEndPage> {
     }
   }
 
-  Color resultColor(){
+  Color resultColor() {
     if (widget.correctAmount == widget.totalQuestions) {
       return Colors.green.withAlpha(50);
     } else if (widget.correctAmount == 0) {
@@ -47,52 +47,57 @@ class _QuizGameEndPageState extends State<QuizGameEndPage> {
 
   @override
   Widget build(BuildContext context) => Scaffold(
+        resizeToAvoidBottomInset: false,
         appBar: AppBar(
           title: const Text('Results'),
         ),
-        body: Column(
-          spacing: 40,
-          children: [
-            const Center(
-              child: Text(
-                'Result summary: ',
-                style: TextStyle(
-                  fontSize: 30,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-            ),
-            Center(
-              child: Container(
-                margin: const EdgeInsets.all(20),
-                padding: const EdgeInsets.all(20),
-                decoration: BoxDecoration(
-                  color: resultColor(),
-                  borderRadius: BorderRadius.circular(15),
-                ),
+        body: SingleChildScrollView(
+          child: Column(
+            spacing: 40,
+            children: [
+              const Center(
                 child: Text(
-                  '${widget.correctAmount}/${widget.totalQuestions} correct!',
-                  style: const TextStyle(
-                    fontSize: 25,
+                  'Result summary: ',
+                  style: TextStyle(
+                    fontSize: 30,
+                    fontWeight: FontWeight.bold,
                   ),
                 ),
               ),
-            ),
-            Center(
-              child: Text(
-                resultMessage(),
-                style: const TextStyle(fontSize: 25),
-              ),
-            ),
-            Center(
-              child: SizedBox(
-                child: Image.asset(
-                  resultImageFile(),
-                  fit: BoxFit.contain,
+              Center(
+                child: Container(
+                  margin: const EdgeInsets.all(20),
+                  padding: const EdgeInsets.all(20),
+                  decoration: BoxDecoration(
+                    color: resultColor(),
+                    borderRadius: BorderRadius.circular(15),
+                  ),
+                  child: Text(
+                    '${widget.correctAmount}/${widget.totalQuestions} correct!',
+                    style: const TextStyle(
+                      fontSize: 25,
+                    ),
+                  ),
                 ),
               ),
-            )
-          ],
+              Center(
+                child: Text(
+                  resultMessage(),
+                  style: const TextStyle(fontSize: 25),
+                ),
+              ),
+              Center(
+                child: SizedBox(
+                  height: 300,
+                  width: 300,
+                  child: Image.asset(
+                    resultImageFile(),
+                    fit: BoxFit.contain,
+                  ),
+                ),
+              )
+            ],
+          ),
         ),
       );
 }


### PR DESCRIPTION
### **User description**
On android, the result image overflows the screen, which causes problems. The images are now smaller by default.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed bottom overflow issue on Android devices

- Added scrollable container to prevent screen overflow

- Set fixed dimensions for result images


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Quiz Results Page"] --> B["Add ScrollView"]
  B --> C["Set Image Dimensions"]
  C --> D["Prevent Bottom Overflow"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>quiz_game_end_page.dart</strong><dd><code>Fix overflow with scrollable layout and image sizing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/ui/pages/quiz_game_end_page.dart

<li>Added <code>resizeToAvoidBottomInset: false</code> to Scaffold<br> <li> Wrapped body content in <code>SingleChildScrollView</code><br> <li> Set fixed height and width (300x300) for result images<br> <li> Minor formatting fix for <code>resultColor()</code> method


</details>


  </td>
  <td><a href="https://github.com/PTLam-Thryve/quizlet_clone/pull/44/files#diff-4ad37ce9eabed75bc3cce7b47f3174773891717bf9f1c74c1964736835e34c85">+42/-37</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>